### PR TITLE
WIP: Stop walking through buffer if it's a non-GIF

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,6 @@ function AnimatedGifDetector(buffer, options) {
   Writable.call(this, options);
   this.buffer = new Buffer(0);
   this.isGIF = false;
-  this.chunks = 0;
 }
 
 AnimatedGifDetector.prototype.isAnimated = function(buffer) {
@@ -51,14 +50,10 @@ AnimatedGifDetector.prototype._write = function(chunk, enc, next) {
     this.isGIF = this.buffer.slice(0, 3).toString() === 'GIF';
 
   // If it's the first chunk of stream we analyze and is not GIF, stop
-  if ((this.isGIF === false) && (this.chunks == 0)) {
+  if (this.isGIF === false) {
     this.emit('finish');
     return;
   }
-  this.chunks += 1;
-
-  if (this.isGIF === false)
-    return next();
 
   if (animated)
     this.emit('animated');

--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@ inherits(AnimatedGifDetector, Writable);
 function AnimatedGifDetector(buffer, options) {
   Writable.call(this, options);
   this.buffer = new Buffer(0);
-  this.isGIF = false;
 }
 
 AnimatedGifDetector.prototype.isAnimated = function(buffer) {
@@ -46,17 +45,17 @@ AnimatedGifDetector.prototype._write = function(chunk, enc, next) {
     , animated = this.isAnimated(this.buffer)
   ;
 
-  if (this.buffer.length > 4)
+  if (this.buffer.length > 4 && this.isGIF == undefined)
     this.isGIF = this.buffer.slice(0, 3).toString() === 'GIF';
 
   // If it's the first chunk of stream we analyze and is not GIF, stop
-  if (this.isGIF === false) {
-    this.emit('finish');
-    return;
-  }
+  if (this.isGIF === false)
+    return this.emit('finish');
 
-  if (animated)
+  if (animated) {
     this.emit('animated');
+    return this.emit('finish');
+  }
 
   next();
 };

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ function AnimatedGifDetector(buffer, options) {
   Writable.call(this, options);
   this.buffer = new Buffer(0);
   this.isGIF = false;
+  this.chunks = 0;
 }
 
 AnimatedGifDetector.prototype.isAnimated = function(buffer) {
@@ -48,6 +49,13 @@ AnimatedGifDetector.prototype._write = function(chunk, enc, next) {
 
   if (this.buffer.length > 4)
     this.isGIF = this.buffer.slice(0, 3).toString() === 'GIF';
+
+  // If it's the first chunk of stream we analyze and is not GIF, stop
+  if ((this.isGIF === false) && (this.chunks == 0)) {
+    this.emit('finish');
+    return;
+  }
+  this.chunks += 1;
 
   if (this.isGIF === false)
     return next();


### PR DESCRIPTION
If we are reading the first bytes of the buffer and its signature says it's not a GIF, we don't need to go ahead. In situations like with big non-GIF images we need to wait until the end of file just to discover it's not a GIF and obviously not animated.

What's your opinion @tbuchok?