### PR TITLE
Avoid the typechecker dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var Writable = require('stream').Writable
   , inherits = require('inherits')
-  , types = require('typechecker')
   // GIF CONSTANTS: http://www.matthewflickinger.com/lab/whatsinagif/bits_and_bytes.asp
   , BLOCK_TERMINATOR = { value: new Buffer('00') }
   , EXTENSION_INTRODUCER = {
@@ -62,8 +61,8 @@ AnimatedGifDetector.prototype._write = function(chunk, enc, next) {
 
 module.exports = function(buffer) {
   if (buffer) {
-    var valid = types.isString(buffer)
-      || types.isNumber(buffer)
+    var valid = typeof buffer === 'string'
+      || typeof buffer === 'number'
       || Buffer.isBuffer(buffer)
     ;
     if (!valid)

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ AnimatedGifDetector.prototype.isAnimated = function(buffer) {
 
 AnimatedGifDetector.prototype._write = function(chunk, enc, next) {
   this.buffer = Buffer.concat([this.buffer, chunk])
-    , animated = this.isAnimated(this.buffer)
+  var animated = this.isAnimated(this.buffer)
   ;
 
   if (this.buffer.length > 4 && this.isGIF == undefined)

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "tap": "^0.4.11"
   },
   "dependencies": {
-    "inherits": "^2.0.1",
-    "typechecker": "^4.0.0"
+    "inherits": "^2.0.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It uses ES6 syntax, which does not work with older node.js versions.